### PR TITLE
ユーザー：カート画面の荷物預かり表示

### DIFF
--- a/resources/views/user/reservations/cart.blade.php
+++ b/resources/views/user/reservations/cart.blade.php
@@ -151,7 +151,7 @@
                                                         <p>{{ $ser[1] }}<span>円</span></p>
                                                     </li>
                                                 @endforeach
-                                                @if (optional($reservation[0])['luggage_count'] || optional($reservation[0])['luggage_arrive'] || optional($reservation[0])['luggage_return'])
+                                                @if (optional($reservation[0])['luggage_flag'] || optional($reservation[0])['luggage_count'] || optional($reservation[0])['luggage_arrive'] || optional($reservation[0])['luggage_return'])
                                                     <li>
                                                         <p>荷物預かり/返送</p>
                                                         <p>500<span>円</span></p>


### PR DESCRIPTION
以下対応を行いました。
ご確認のほどよろしくお願いいたします。

※「荷物預かり：あり」の場合のみでよいと思いましたが、
「user/reservations/check」の記述と合わせました。

バックログ：
https://ts-pj.backlog.com/view/SMG-204