### PR TITLE
イベント開始・終了時刻の修正

### DIFF
--- a/public/js/template.js
+++ b/public/js/template.js
@@ -155,16 +155,16 @@ $(function () {
 	$('#sales_start').on('change', function () {
 	  var child_target = $('#event_start').val();
 	  $('#event_start option').prop('disabled', false);
-      if ($(this).val() > child_target || $('#event_start').is(':disabled')) {
-        $('#event_start').val($(this).val());
+    if ($(this).val() > child_target || $('#event_start').is(':disabled')) {
+      $('#event_start').val($(this).val());
 		// swal('イベント開始時間は入室時間より後に設定してください');
 	  }
 	})
 	$('#sales_finish').on('change', function () {
 	  var child_target2 = $('#event_finish').val();
 	  $('#event_finish option').prop('disabled', false);
-      if ($(this).val() < child_target2 || $('#event_finish').is(':disabled')) {
-        $('#event_finish').val($(this).val());
+    if ($(this).val() < child_target2 || $('#event_finish').is(':disabled')) {
+      $('#event_finish').val($(this).val());
 		// swal('イベント終了時間は退室時間より前に設定してください');
 	  }
 	})

--- a/public/js/template.js
+++ b/public/js/template.js
@@ -155,16 +155,16 @@ $(function () {
 	$('#sales_start').on('change', function () {
 	  var child_target = $('#event_start').val();
 	  $('#event_start option').prop('disabled', false);
-	  if ($(this).val() > child_target) {
-		$('#event_start').val('');
+    if ($(this).val() > child_target || $('#event_start').is(':disabled')) {
+      $('#event_start').val($(this).val());
 		// swal('イベント開始時間は入室時間より後に設定してください');
 	  }
 	})
 	$('#sales_finish').on('change', function () {
 	  var child_target2 = $('#event_finish').val();
 	  $('#event_finish option').prop('disabled', false);
-	  if ($(this).val() < child_target2) {
-		$('#event_finish').val('');
+    if ($(this).val() < child_target2 || $('#event_finish').is(':disabled')) {
+      $('#event_finish').val($(this).val());
 		// swal('イベント終了時間は退室時間より前に設定してください');
 	  }
 	})

--- a/public/js/template.js
+++ b/public/js/template.js
@@ -155,16 +155,16 @@ $(function () {
 	$('#sales_start').on('change', function () {
 	  var child_target = $('#event_start').val();
 	  $('#event_start option').prop('disabled', false);
-    if ($(this).val() > child_target || $('#event_start').is(':disabled')) {
-      $('#event_start').val($(this).val());
+      if ($(this).val() > child_target || $('#event_start').is(':disabled')) {
+        $('#event_start').val($(this).val());
 		// swal('イベント開始時間は入室時間より後に設定してください');
 	  }
 	})
 	$('#sales_finish').on('change', function () {
 	  var child_target2 = $('#event_finish').val();
 	  $('#event_finish option').prop('disabled', false);
-    if ($(this).val() < child_target2 || $('#event_finish').is(':disabled')) {
-      $('#event_finish').val($(this).val());
+      if ($(this).val() < child_target2 || $('#event_finish').is(':disabled')) {
+        $('#event_finish').val($(this).val());
 		// swal('イベント終了時間は退室時間より前に設定してください');
 	  }
 	})

--- a/resources/views/admin/agents_reservations/calculate.blade.php
+++ b/resources/views/admin/agents_reservations/calculate.blade.php
@@ -175,12 +175,10 @@
                                 <td>
                                     <div>
                                         <select name="event_start" id="event_start" class="form-control">
-                                            @if ($master_info['board_flag'] == 1)
-                                                <option value="" disabled>選択してください</option>
-                                                {!! ReservationHelper::timeOptionsWithRequestAndLimit($master_info['event_start'], $master_info['enter_time'], $master_info['leave_time']) !!}
+                                            @if ($master_info['board_flag'] === 0)
+                                                {!! ReservationHelper::timeOptionsWithRequestAndLimit($master_info['enter_time'], $master_info['enter_time'], $master_info['leave_time']) !!}
                                             @else
-                                                <option value="" selected></option>
-                                                {!! ReservationHelper::timeOptionsWithRequestAndLimit('', $master_info['enter_time'], $master_info['leave_time']) !!}
+                                                {!! ReservationHelper::timeOptionsWithRequestAndLimit($master_info['event_start'] ?? $master_info['enter_time'], $master_info['enter_time'], $master_info['leave_time']) !!}
                                             @endif
                                         </select>
                                     </div>
@@ -192,12 +190,10 @@
                                     <div>
                                         <select name="event_finish" id="event_finish" class="form-control">
 
-                                            @if ($master_info['board_flag'] == 1)
-                                                <option value="" disabled>選択してください</option>
-                                                {!! ReservationHelper::timeOptionsWithRequestAndLimit($master_info['event_finish'], $master_info['enter_time'], $master_info['leave_time']) !!}
+                                            @if ($master_info['board_flag'] === 0)
+                                                {!! ReservationHelper::timeOptionsWithRequestAndLimit($master_info['leave_time'], $master_info['enter_time'], $master_info['leave_time']) !!}
                                             @else
-                                                <option value="" selected></option>
-                                                {!! ReservationHelper::timeOptionsWithRequestAndLimit('', $master_info['enter_time'], $master_info['leave_time']) !!}
+                                                {!! ReservationHelper::timeOptionsWithRequestAndLimit($master_info['event_finish'] ?? $master_info['leave_time'], $master_info['enter_time'], $master_info['leave_time']) !!}
                                             @endif
 
                                         </select>

--- a/resources/views/admin/agents_reservations/check.blade.php
+++ b/resources/views/admin/agents_reservations/check.blade.php
@@ -149,7 +149,9 @@
                             <td class="table-active">イベント開始時間</td>
                             <td>
                                 <div>
-                                    {{ Form::text('', !empty($master_info['event_start']) ? ReservationHelper::formatTime($master_info['event_start']) : '', ['class' => 'form-control', 'readonly']) }}
+                                    @if (!empty($master_info['event_start']))
+                                        {{ Form::text('', ($master_info['event_start'] !== '00:00:00') ? ReservationHelper::formatTime($master_info['event_start']) : '', ['class' => 'form-control', 'readonly']) }}
+                                    @endif
                                     {{ Form::hidden('event_start', !empty($master_info['event_start']) ? $master_info['event_start'] : '', ['class' => 'form-control', 'readonly']) }}
                                 </div>
                             </td>
@@ -157,7 +159,9 @@
                         <tr>
                             <td class="table-active">イベント終了時間</td>
                             <td>
-                                {{ Form::text('', !empty($master_info['event_finish']) ? ReservationHelper::formatTime($master_info['event_finish']) : '', ['class' => 'form-control', 'readonly']) }}
+                                @if (!empty($master_info['event_finish']))
+                                    {{ Form::text('', ($master_info['event_finish'] !== '00:00:00') ? ReservationHelper::formatTime($master_info['event_finish']) : '', ['class' => 'form-control', 'readonly']) }}
+                                @endif
                                 {{ Form::hidden('event_finish', !empty($master_info['event_finish']) ? $master_info['event_finish'] : '', ['class' => 'form-control', 'readonly']) }}
                             </td>
                         </tr>

--- a/resources/views/admin/agents_reservations/create.blade.php
+++ b/resources/views/admin/agents_reservations/create.blade.php
@@ -198,7 +198,6 @@
             <td>
               <div>
                 <select name="event_start" id="event_start" class="form-control">
-                  <option disabled>選択してください</option>
                   {!!ReservationHelper::timeOptions()!!}
                 </select>
               </div>
@@ -209,7 +208,6 @@
             <td>
               <div>
                 <select name="event_finish" id="event_finish" class="form-control">
-                  <option disabled>選択してください</option>
                   {!!ReservationHelper::timeOptions()!!}
                 </select>
               </div>

--- a/resources/views/admin/agents_reservations/edit.blade.php
+++ b/resources/views/admin/agents_reservations/edit.blade.php
@@ -190,12 +190,10 @@
                         <td class="table-active">イベント開始時間</td>
                         <td>
                             <select name="event_start" id="event_start" class="form-control">
-                                @if ($reservation['board_flag'] == 1)
-                                    <option value="" disabled>選択してください</option>
-                                    {!! ReservationHelper::timeOptionsWithRequestAndLimit($reservation['event_start'], $reservation['enter_time'], $reservation['leave_time']) !!}
+                                @if ($reservation['board_flag'] === 0)
+                                    {!! ReservationHelper::timeOptionsWithRequestAndLimit($reservation['enter_time'], $reservation['enter_time'], $reservation['leave_time']) !!}
                                 @else
-                                    <option value="" selected></option>
-                                    {!! ReservationHelper::timeOptionsWithRequestAndLimit('', $reservation['enter_time'], $reservation['leave_time']) !!}
+                                    {!! ReservationHelper::timeOptionsWithRequestAndLimit($reservation['event_start'], $reservation['enter_time'], $reservation['leave_time']) !!}
                                 @endif
                             </select>
                         </td>
@@ -204,12 +202,10 @@
                         <td class="table-active">イベント終了時間</td>
                         <td>
                             <select name="event_finish" id="event_finish" class="form-control">
-                                @if ($reservation['board_flag'] == 1)
-                                    <option value="" disabled>選択してください</option>
-                                    {!! ReservationHelper::timeOptionsWithRequestAndLimit($reservation['event_finish'], $reservation['enter_time'], $reservation['leave_time']) !!}
+                                @if ($reservation['board_flag'] === 0)
+                                    {!! ReservationHelper::timeOptionsWithRequestAndLimit($reservation['leave_time'], $reservation['enter_time'], $reservation['leave_time']) !!}
                                 @else
-                                    <option value="" selected></option>
-                                    {!! ReservationHelper::timeOptionsWithRequestAndLimit('', $reservation['enter_time'], $reservation['leave_time']) !!}
+                                    {!! ReservationHelper::timeOptionsWithRequestAndLimit($reservation['event_finish'], $reservation['enter_time'], $reservation['leave_time']) !!}
                                 @endif
                             </select>
                         </td>

--- a/resources/views/admin/agents_reservations/edit_calc.blade.php
+++ b/resources/views/admin/agents_reservations/edit_calc.blade.php
@@ -179,12 +179,10 @@
                         <td class="table-active">イベント開始時間</td>
                         <td>
                             <select name="event_start" id="event_start" class="form-control">
-                                @if ($data['board_flag'] == 1)
-                                    <option value="" disabled>選択してください</option>
-                                    {!! ReservationHelper::timeOptionsWithRequestAndLimit($data['event_start'], $data['enter_time'], $data['leave_time']) !!}
+                                @if ($data['board_flag'] === 0)
+                                    {!! ReservationHelper::timeOptionsWithRequestAndLimit($data['enter_time'], $data['enter_time'], $data['leave_time']) !!}
                                 @else
-                                    <option value="" selected></option>
-                                    {!! ReservationHelper::timeOptionsWithRequestAndLimit('', $data['enter_time'], $data['leave_time']) !!}
+                                    {!! ReservationHelper::timeOptionsWithRequestAndLimit($data['event_start'] ?? $data['enter_time'], $data['enter_time'], $data['leave_time']) !!}
                                 @endif
                             </select>
                         </td>
@@ -193,12 +191,10 @@
                         <td class="table-active">イベント終了時間</td>
                         <td>
                             <select name="event_finish" id="event_finish" class="form-control">
-                                @if ($data['board_flag'] == 1)
-                                    <option value="" disabled>選択してください</option>
-                                    {!! ReservationHelper::timeOptionsWithRequestAndLimit($data['event_finish'], $data['enter_time'], $data['leave_time']) !!}
+                                @if ($data['board_flag'] === 0)
+                                    {!! ReservationHelper::timeOptionsWithRequestAndLimit($data['leave_time'], $data['enter_time'], $data['leave_time']) !!}
                                 @else
-                                    <option value="" selected></option>
-                                    {!! ReservationHelper::timeOptionsWithRequestAndLimit('', $data['enter_time'], $data['leave_time']) !!}
+                                    {!! ReservationHelper::timeOptionsWithRequestAndLimit($data['event_finish'] ?? $data['leave_time'], $data['enter_time'], $data['leave_time']) !!}
                                 @endif
                             </select>
                         </td>

--- a/resources/views/admin/agents_reservations/edit_check.blade.php
+++ b/resources/views/admin/agents_reservations/edit_check.blade.php
@@ -100,7 +100,11 @@
                             <td class="table-active">イベント開始時間</td>
                             <td>
                                 @if ($data['board_flag'] == 1)
-                                    {{ Form::text('', date('H:i', strtotime($data['event_start'])), ['class' => 'form-control', 'readonly']) }}
+                                    @if ($data['event_start'] === '00:00:00')
+                                        {{ Form::text('', '', ['class' => 'form-control', 'readonly']) }}
+                                    @else
+                                        {{ Form::text('', date('H:i', strtotime($data['event_start'])), ['class' => 'form-control', 'readonly']) }}
+                                    @endif
                                     {{ Form::hidden('event_start', $data['event_start'], ['class' => 'form-control', 'readonly']) }}
                                 @else
                                     {{ Form::text('', '', ['class' => 'form-control', 'readonly']) }}
@@ -112,8 +116,12 @@
                             <td class="table-active">イベント終了時間</td>
                             <td>
                                 @if ($data['board_flag'] == 1)
-                                    {{ Form::text('', date('H:i', strtotime($data['event_finish'])), ['class' => 'form-control', 'readonly']) }}
-                                    {{ Form::hidden('event_finish', $data['event_start'], ['class' => 'form-control', 'readonly']) }}
+                                    @if ($data['event_finish'] === '00:00:00')
+                                        {{ Form::text('', '', ['class' => 'form-control', 'readonly']) }}
+                                    @else
+                                        {{ Form::text('', date('H:i', strtotime($data['event_finish'])), ['class' => 'form-control', 'readonly']) }}
+                                    @endif
+                                    {{ Form::hidden('event_finish', $data['event_finish'], ['class' => 'form-control', 'readonly']) }}
                                 @else
                                     {{ Form::text('', '', ['class' => 'form-control', 'readonly']) }}
                                     {{ Form::hidden('event_finish', '', ['class' => 'form-control', 'readonly']) }}

--- a/resources/views/admin/pre_agent_reservations/edit.blade.php
+++ b/resources/views/admin/pre_agent_reservations/edit.blade.php
@@ -313,8 +313,11 @@
                             <td class="table-active">イベント開始時間</td>
                             <td>
                                 <select name="event_start" id="event_start" class="form-control">
-                                    <option value=""></option>
-                                    {!! ReservationHelper::timeOptionsWithRequestAndLimit($PreReservation->event_start, $PreReservation->enter_time, $PreReservation->leave_time) !!}
+                                    @if ($PreReservation->board_flag === 0)
+                                        {!! ReservationHelper::timeOptionsWithRequestAndLimit($PreReservation->enter_time, $PreReservation->enter_time, $PreReservation->leave_time) !!}
+                                    @else
+                                        {!! ReservationHelper::timeOptionsWithRequestAndLimit($PreReservation->event_start, $PreReservation->enter_time, $PreReservation->leave_time) !!}
+                                    @endif
                                 </select>
                             </td>
                         </tr>
@@ -322,8 +325,11 @@
                             <td class="table-active">イベント終了時間</td>
                             <td>
                                 <select name="event_finish" id="event_finish" class="form-control">
-                                    <option value=""></option>
-                                    {!! ReservationHelper::timeOptionsWithRequestAndLimit($PreReservation->event_finish, $PreReservation->enter_time, $PreReservation->leave_time) !!}
+                                    @if ($PreReservation->board_flag === 0)
+                                        {!! ReservationHelper::timeOptionsWithRequestAndLimit($PreReservation->leave_time, $PreReservation->enter_time, $PreReservation->leave_time) !!}
+                                    @else
+                                        {!! ReservationHelper::timeOptionsWithRequestAndLimit($PreReservation->event_finish, $PreReservation->enter_time, $PreReservation->leave_time) !!}
+                                    @endif
                                 </select>
                             </td>
                         </tr>

--- a/resources/views/admin/pre_agent_reservations/single_calculate.blade.php
+++ b/resources/views/admin/pre_agent_reservations/single_calculate.blade.php
@@ -279,12 +279,10 @@
                             <td class="table-active">イベント開始時間</td>
                             <td>
                                 <select name="event_start" id="event_start" class="form-control">
-                                    @if ($request->board_flag == 1)
-                                        <option value="" disabled>選択してください</option>
-                                        {!! ReservationHelper::timeOptionsWithRequestAndLimit($request->event_start, $request->enter_time, $request->leave_time) !!}
+                                    @if ($request->board_flag === 0)
+                                        {!! ReservationHelper::timeOptionsWithRequestAndLimit($request->enter_time, $request->enter_time, $request->leave_time) !!}
                                     @else
-                                        <option value="" selected></option>
-                                        {!! ReservationHelper::timeOptionsWithRequestAndLimit('', $request->enter_time, $request->leave_time) !!}
+                                        {!! ReservationHelper::timeOptionsWithRequestAndLimit($request->event_start ?? $request->enter_time, $request->enter_time, $request->leave_time) !!}
                                     @endif
                                 </select>
                             </td>
@@ -293,12 +291,10 @@
                             <td class="table-active">イベント終了時間</td>
                             <td>
                                 <select name="event_finish" id="event_finish" class="form-control">
-                                    @if ($request->board_flag == 1)
-                                        <option value="" disabled>選択してください</option>
-                                        {!! ReservationHelper::timeOptionsWithRequestAndLimit($request->event_finish, $request->enter_time, $request->leave_time) !!}
+                                    @if ($request->board_flag === 0)
+                                        {!! ReservationHelper::timeOptionsWithRequestAndLimit($request->leave_time, $request->enter_time, $request->leave_time) !!}
                                     @else
-                                        <option value="" selected></option>
-                                        {!! ReservationHelper::timeOptionsWithRequestAndLimit('', $request->enter_time, $request->leave_time) !!}
+                                        {!! ReservationHelper::timeOptionsWithRequestAndLimit($request->event_finish ?? $request->leave_time, $request->enter_time, $request->leave_time) !!}
                                     @endif
 
                                 </select>

--- a/resources/views/admin/pre_agent_reservations/single_check.blade.php
+++ b/resources/views/admin/pre_agent_reservations/single_check.blade.php
@@ -280,7 +280,6 @@
                             <td>
                                 <div>
                                     <select name="event_start" id="event_start" class="form-control">
-                                        <option disabled>選択してください</option>
                                         {!! ReservationHelper::timeOptionsWithRequestAndLimit($request->pre_enter0, $request->pre_enter0, $request->pre_leave0) !!}
                                     </select>
                                 </div>
@@ -291,7 +290,6 @@
                             <td>
                                 <div>
                                     <select name="event_finish" id="event_finish" class="form-control">
-                                        <option disabled>選択してください</option>
                                         {!! ReservationHelper::timeOptionsWithRequestAndLimit($request->pre_leave0, $request->pre_enter0, $request->pre_leave0) !!}
                                     </select>
                                 </div>

--- a/resources/views/admin/pre_reservations/edit.blade.php
+++ b/resources/views/admin/pre_reservations/edit.blade.php
@@ -301,12 +301,10 @@
                             <td class="table-active">イベント開始時間</td>
                             <td>
                                 <select name="event_start" id="event_start" class="form-control">
-                                    @if ($PreReservation->board_flag == 1)
-                                        <option disabled>選択してください</option>
-                                        {!! ReservationHelper::timeOptionsWithRequestAndLimit($PreReservation->event_start, $PreReservation->enter_time, $PreReservation->leave_time) !!}
+                                    @if ($PreReservation->board_flag === 0)
+                                        {!! ReservationHelper::timeOptionsWithRequestAndLimit($PreReservation->enter_time, $PreReservation->enter_time, $PreReservation->leave_time) !!}
                                     @else
-                                        <option value="" selected></option>
-                                        {!! ReservationHelper::timeOptionsWithRequestAndLimit('', $PreReservation->enter_time, $PreReservation->leave_time) !!}
+                                        {!! ReservationHelper::timeOptionsWithRequestAndLimit($PreReservation->event_start, $PreReservation->enter_time, $PreReservation->leave_time) !!}
                                     @endif
                                 </select>
                             </td>
@@ -315,12 +313,10 @@
                             <td class="table-active">イベント終了時間</td>
                             <td>
                                 <select name="event_finish" id="event_finish" class="form-control">
-                                    @if ($PreReservation->board_flag == 1)
-                                        <option disabled>選択してください</option>
-                                        {!! ReservationHelper::timeOptionsWithRequestAndLimit($PreReservation->event_finish, $PreReservation->enter_time, $PreReservation->leave_time) !!}
+                                    @if ($PreReservation->board_flag === 0)
+                                        {!! ReservationHelper::timeOptionsWithRequestAndLimit($PreReservation->leave_time, $PreReservation->enter_time, $PreReservation->leave_time) !!}
                                     @else
-                                        <option value="" selected></option>
-                                        {!! ReservationHelper::timeOptionsWithRequestAndLimit('', $PreReservation->enter_time, $PreReservation->leave_time) !!}
+                                        {!! ReservationHelper::timeOptionsWithRequestAndLimit($PreReservation->event_finish, $PreReservation->enter_time, $PreReservation->leave_time) !!}
                                     @endif
 
                                 </select>

--- a/resources/views/admin/pre_reservations/show.blade.php
+++ b/resources/views/admin/pre_reservations/show.blade.php
@@ -404,14 +404,18 @@
                                     <td class="table-active"><label for="eventStart">イベント開始時間</label>
                                     </td>
                                     <td>
-                                        {{ ReservationHelper::formatTime($pre_reservation->event_start) }}
+                                        @if ($pre_reservation->event_start !== '00:00:00')
+                                            {{ ReservationHelper::formatTime($pre_reservation->event_start) }}
+                                        @endif
                                     </td>
                                 </tr>
                                 <tr>
                                     <td class="table-active"><label for="eventFinish">イベント終了時間</label>
                                     </td>
                                     <td>
-                                        {{ ReservationHelper::formatTime($pre_reservation->event_finish) }}
+                                        @if ($pre_reservation->event_finish !== '00:00:00')
+                                            {{ ReservationHelper::formatTime($pre_reservation->event_finish) }}
+                                        @endif
                                     </td>
                                 </tr>
                             </table>

--- a/resources/views/admin/pre_reservations/single_calculate.blade.php
+++ b/resources/views/admin/pre_reservations/single_calculate.blade.php
@@ -249,12 +249,10 @@
                             <td class="table-active">イベント開始時間</td>
                             <td>
                                 <select name="event_start" id="event_start" class="form-control">
-                                    @if ($request->board_flag == 1)
-                                        <option value="" disabled>選択してください</option>
-                                        {!! ReservationHelper::timeOptionsWithRequestAndLimit($request->event_start, $request->enter_time, $request->leave_time) !!}
+                                    @if ($request->board_flag === 0)
+                                        {!! ReservationHelper::timeOptionsWithRequestAndLimit($request->enter_time, $request->enter_time, $request->leave_time) !!}
                                     @else
-                                        <option value="" selected></option>
-                                        {!! ReservationHelper::timeOptionsWithRequestAndLimit('', $request->enter_time, $request->leave_time) !!}
+                                        {!! ReservationHelper::timeOptionsWithRequestAndLimit($request->event_start ?? $request->enter_time, $request->enter_time, $request->leave_time) !!}
                                     @endif
                                 </select>
                             </td>
@@ -263,12 +261,10 @@
                             <td class="table-active">イベント終了時間</td>
                             <td>
                                 <select name="event_finish" id="event_finish" class="form-control">
-                                    @if ($request->board_flag == 1)
-                                        <option disabled>選択してください</option>
-                                        {!! ReservationHelper::timeOptionsWithRequestAndLimit($request->event_finish, $request->enter_time, $request->leave_time) !!}
+                                    @if ($request->board_flag === 0)
+                                        {!! ReservationHelper::timeOptionsWithRequestAndLimit($request->leave_time, $request->enter_time, $request->leave_time) !!}
                                     @else
-                                        <option value="" selected></option>
-                                        {!! ReservationHelper::timeOptionsWithRequestAndLimit($request->event_finish, $request->enter_time, $request->leave_time) !!}
+                                        {!! ReservationHelper::timeOptionsWithRequestAndLimit($request->event_finish ?? $request->leave_time, $request->enter_time, $request->leave_time) !!}
                                     @endif
                                 </select>
                             </td>

--- a/resources/views/admin/pre_reservations/single_check.blade.php
+++ b/resources/views/admin/pre_reservations/single_check.blade.php
@@ -262,7 +262,6 @@
                                 <td>
                                     <div>
                                         <select name="event_start" id="event_start" class="form-control">
-                                            <option disabled>選択してください</option>
                                             {!! ReservationHelper::timeOptionsWithRequestAndLimit($request->pre_enter0, $request->pre_enter0, $request->pre_leave0) !!}
                                         </select>
                                     </div>
@@ -273,7 +272,6 @@
                                 <td>
                                     <div>
                                         <select name="event_finish" id="event_finish" class="form-control">
-                                            <option disabled>選択してください</option>
                                             {!! ReservationHelper::timeOptionsWithRequestAndLimit($request->pre_leave0, $request->pre_enter0, $request->pre_leave0) !!}
                                         </select>
                                     </div>

--- a/resources/views/admin/pre_reservations/single_re_calculate.blade.php
+++ b/resources/views/admin/pre_reservations/single_re_calculate.blade.php
@@ -264,12 +264,10 @@
                             <td class="table-active">イベント開始時間</td>
                             <td>
                                 <select name="event_start" id="event_start" class="form-control">
-                                    @if ($request->board_flag == 1)
-                                        <option disabled>選択してください</option>
-                                        {!! ReservationHelper::timeOptionsWithRequestAndLimit($request->event_start, $request->enter_time, $request->leave_time) !!}
+                                    @if ($request->board_flag === 0)
+                                        {!! ReservationHelper::timeOptionsWithRequestAndLimit($request->enter_time, $request->enter_time, $request->leave_time) !!}
                                     @else
-                                        <option value="" selected></option>
-                                        {!! ReservationHelper::timeOptionsWithRequestAndLimit('', $request->enter_time, $request->leave_time) !!}
+                                        {!! ReservationHelper::timeOptionsWithRequestAndLimit($request->event_start ?? $request->enter_time, $request->enter_time, $request->leave_time) !!}
                                     @endif
                                 </select>
                             </td>
@@ -278,12 +276,10 @@
                             <td class="table-active">イベント終了時間</td>
                             <td>
                                 <select name="event_finish" id="event_finish" class="form-control">
-                                    @if ($request->board_flag == 1)
-                                        <option disabled>選択してください</option>
-                                        {!! ReservationHelper::timeOptionsWithRequestAndLimit($request->event_finish, $request->enter_time, $request->leave_time) !!}
+                                    @if ($request->board_flag === 0)
+                                        {!! ReservationHelper::timeOptionsWithRequestAndLimit($request->leave_time, $request->enter_time, $request->leave_time) !!}
                                     @else
-                                        <option value="" selected></option>
-                                        {!! ReservationHelper::timeOptionsWithRequestAndLimit('', $request->enter_time, $request->leave_time) !!}
+                                        {!! ReservationHelper::timeOptionsWithRequestAndLimit($request->event_finish ?? $request->leave_time, $request->enter_time, $request->leave_time) !!}
                                     @endif
 
                                 </select>

--- a/resources/views/admin/reservations/calculate.blade.php
+++ b/resources/views/admin/reservations/calculate.blade.php
@@ -177,13 +177,10 @@
                             <td class="table-active">イベント開始時間</td>
                             <td>
                                 <select name="event_start" id="event_start" class="form-control">
-                                    <option disabled>選択してください</option>
-                                    @if (!empty($value['event_start']) && !empty($value['board_flag']))
-                                        <option value="" disabled>選択してください</option>
-                                        {!! ReservationHelper::timeOptionsWithRequestAndLimit($value['event_start'], $value['enter_time'], $value['leave_time']) !!}
+                                    @if ($value['board_flag'] === 0)
+                                        {!! ReservationHelper::timeOptionsWithRequestAndLimit($value['enter_time'], $value['enter_time'], $value['leave_time']) !!}
                                     @else
-                                        <option value="" selected></option>
-                                        {!! ReservationHelper::timeOptionsWithRequestAndLimit('', $value['enter_time'], $value['leave_time']) !!}
+                                        {!! ReservationHelper::timeOptionsWithRequestAndLimit($value['event_start'] ?? $value['enter_time'], $value['enter_time'], $value['leave_time']) !!}
                                     @endif
                                 </select>
                             </td>
@@ -193,13 +190,10 @@
                             <td class="table-active">イベント終了時間</td>
                             <td>
                                 <select name="event_finish" id="event_finish" class="form-control">
-                                    <option disabled>選択してください</option>
-                                    @if (!empty($value['event_finish']) && !empty($value['board_flag']))
-                                        <option value="" disabled>選択してください</option>
-                                        {!! ReservationHelper::timeOptionsWithRequestAndLimit($value['event_finish'], $value['enter_time'], $value['leave_time']) !!}
+                                    @if ($value['board_flag'] === 0)
+                                        {!! ReservationHelper::timeOptionsWithRequestAndLimit($value['leave_time'], $value['enter_time'], $value['leave_time']) !!}
                                     @else
-                                        <option value="" selected></option>
-                                        {!! ReservationHelper::timeOptionsWithRequestAndLimit('', $value['enter_time'], $value['leave_time']) !!}
+                                        {!! ReservationHelper::timeOptionsWithRequestAndLimit($value['event_finish'] ?? $value['leave_time'], $value['enter_time'], $value['leave_time']) !!}
                                     @endif
                                 </select>
                             </td>

--- a/resources/views/admin/reservations/check.blade.php
+++ b/resources/views/admin/reservations/check.blade.php
@@ -124,7 +124,9 @@
                             <td class="table-active">イベント開始時間</td>
                             <td>
                                 @if (!empty($value['event_start']) && !empty($value['board_flag']))
-                                    {{ date('H:i', strtotime($value['event_start'])) }}
+                                    @if ($value['event_start'] !== '00:00:00')
+                                        {{ date('H:i', strtotime($value['event_start'])) }}
+                                    @endif
                                 @endif
                             </td>
                         </tr>
@@ -132,7 +134,9 @@
                             <td class="table-active">イベント終了時間</td>
                             <td>
                                 @if (!empty($value['event_finish']) && !empty($value['board_flag']))
-                                    {{ date('H:i', strtotime($value['event_finish'])) }}
+                                    @if ($value['event_finish'] !== '00:00:00')
+                                        {{ date('H:i', strtotime($value['event_finish'])) }}
+                                    @endif
                                 @endif
                             </td>
                         </tr>

--- a/resources/views/admin/reservations/create.blade.php
+++ b/resources/views/admin/reservations/create.blade.php
@@ -221,9 +221,7 @@
               <td>
                 <div>
                   <select name="event_finish" id="event_finish" class="form-control">
-                    <option disabled>選択してください</option>
                     {!!ReservationHelper::timeOptions()!!}
-
                   </select>
                 </div>
               </td>

--- a/resources/views/admin/reservations/edit.blade.php
+++ b/resources/views/admin/reservations/edit.blade.php
@@ -199,12 +199,10 @@
                         <td class="table-active">イベント開始時間</td>
                         <td>
                             <select name="event_start" id="event_start" class="form-control">
-                                @if ($reservation['board_flag'] == 1)
-                                    <option value="" disabled>選択してください</option>
-                                    {!! ReservationHelper::timeOptionsWithRequestAndLimit($reservation['event_start'], $reservation['enter_time'], $reservation['leave_time']) !!}
+                                @if ($reservation['board_flag'] === 0)
+                                    {!! ReservationHelper::timeOptionsWithRequestAndLimit($reservation['enter_time'], $reservation['enter_time'], $reservation['leave_time']) !!}
                                 @else
-                                    <option value="" selected></option>
-                                    {!! ReservationHelper::timeOptionsWithRequestAndLimit('', $reservation['enter_time'], $reservation['leave_time']) !!}
+                                    {!! ReservationHelper::timeOptionsWithRequestAndLimit($reservation['event_start'], $reservation['enter_time'], $reservation['leave_time']) !!}
                                 @endif
                             </select>
                         </td>
@@ -213,12 +211,10 @@
                         <td class="table-active">イベント終了時間</td>
                         <td>
                             <select name="event_finish" id="event_finish" class="form-control">
-                                @if ($reservation['board_flag'] == 1)
-                                    <option value="" disabled>選択してください</option>
-                                    {!! ReservationHelper::timeOptionsWithRequestAndLimit($reservation['event_finish'], $reservation['enter_time'], $reservation['leave_time']) !!}
+                                @if ($reservation['board_flag'] === 0)
+                                    {!! ReservationHelper::timeOptionsWithRequestAndLimit($reservation['leave_time'], $reservation['enter_time'], $reservation['leave_time']) !!}
                                 @else
-                                    <option value="" selected></option>
-                                    {!! ReservationHelper::timeOptionsWithRequestAndLimit('', $reservation['enter_time'], $reservation['leave_time']) !!}
+                                    {!! ReservationHelper::timeOptionsWithRequestAndLimit($reservation['event_finish'], $reservation['enter_time'], $reservation['leave_time']) !!}
                                 @endif
                             </select>
                         </td>

--- a/resources/views/admin/reservations/edit_calc.blade.php
+++ b/resources/views/admin/reservations/edit_calc.blade.php
@@ -198,12 +198,10 @@
                         <td class="table-active">イベント開始時間</td>
                         <td>
                             <select name="event_start" id="event_start" class="form-control">
-                                @if ($data['board_flag'] == 1)
-                                    <option value="" disabled>選択してください</option>
-                                    {!! ReservationHelper::timeOptionsWithRequestAndLimit($data['event_start'], $data['enter_time'], $data['leave_time']) !!}
+                                @if ($data['board_flag'] === 0)
+                                    {!! ReservationHelper::timeOptionsWithRequestAndLimit($data['enter_time'], $data['enter_time'], $data['leave_time']) !!}
                                 @else
-                                    <option value="" selected></option>
-                                    {!! ReservationHelper::timeOptionsWithRequestAndLimit('', $data['enter_time'], $data['leave_time']) !!}
+                                    {!! ReservationHelper::timeOptionsWithRequestAndLimit($data['event_start'] ?? $data['enter_time'], $data['enter_time'], $data['leave_time']) !!}
                                 @endif
                             </select>
                         </td>
@@ -212,12 +210,10 @@
                         <td class="table-active">イベント終了時間</td>
                         <td>
                             <select name="event_finish" id="event_finish" class="form-control">
-                                @if ($data['board_flag'] == 1)
-                                    <option value="" disabled>選択してください</option>
-                                    {!! ReservationHelper::timeOptionsWithRequestAndLimit($data['event_finish'], $data['enter_time'], $data['leave_time']) !!}
+                                @if ($data['board_flag'] === 0)
+                                    {!! ReservationHelper::timeOptionsWithRequestAndLimit($data['leave_time'], $data['enter_time'], $data['leave_time']) !!}
                                 @else
-                                    <option value="" selected></option>
-                                    {!! ReservationHelper::timeOptionsWithRequestAndLimit('', $data['enter_time'], $data['leave_time']) !!}
+                                    {!! ReservationHelper::timeOptionsWithRequestAndLimit($data['event_finish'] ?? $data['leave_time'], $data['enter_time'], $data['leave_time']) !!}
                                 @endif
                             </select>
                         </td>

--- a/resources/views/admin/reservations/edit_check.blade.php
+++ b/resources/views/admin/reservations/edit_check.blade.php
@@ -108,7 +108,11 @@
                             <td class="table-active">イベント開始時間</td>
                             <td>
                                 @if ($data['board_flag'] == 1)
-                                    {{ Form::text('', date('H:i', strtotime($data['event_start'])), ['class' => 'form-control', 'readonly']) }}
+                                    @if ($data['event_start'] === '00:00:00')
+                                        {{ Form::text('', '', ['class' => 'form-control', 'readonly']) }}
+                                    @else
+                                        {{ Form::text('', date('H:i', strtotime($data['event_start'])), ['class' => 'form-control', 'readonly']) }}
+                                    @endif
                                     {{ Form::hidden('event_start', $data['event_start'], ['class' => 'form-control', 'readonly']) }}
                                 @else
                                     {{ Form::text('', '', ['class' => 'form-control', 'readonly']) }}
@@ -120,8 +124,12 @@
                             <td class="table-active">イベント終了時間</td>
                             <td>
                                 @if ($data['board_flag'] == 1)
-                                    {{ Form::text('', date('H:i', strtotime($data['event_finish'])), ['class' => 'form-control', 'readonly']) }}
-                                    {{ Form::hidden('event_finish', $data['event_start'], ['class' => 'form-control', 'readonly']) }}
+                                    @if ($data['event_start'] === '00:00:00')
+                                        {{ Form::text('', '', ['class' => 'form-control', 'readonly']) }}
+                                    @else
+                                        {{ Form::text('', date('H:i', strtotime($data['event_finish'])), ['class' => 'form-control', 'readonly']) }}
+                                    @endif
+                                    {{ Form::hidden('event_finish', $data['event_finish'], ['class' => 'form-control', 'readonly']) }}
                                 @else
                                     {{ Form::text('', '', ['class' => 'form-control', 'readonly']) }}
                                     {{ Form::hidden('event_finish', '', ['class' => 'form-control', 'readonly']) }}

--- a/resources/views/admin/reservations/show.blade.php
+++ b/resources/views/admin/reservations/show.blade.php
@@ -214,7 +214,7 @@
                             <td class="table-active"><label for="eventStart">イベント開始時間</label></td>
                             <td>
                                 @if (!empty($reservation->board_flag))
-                                    {{ ReservationHelper::formatTime($reservation->event_start) }}
+                                    {{ $reservation->event_start === '00:00:00' ? '' : ReservationHelper::formatTime($reservation->event_start) }}
                                 @endif
                             </td>
                         </tr>
@@ -222,7 +222,7 @@
                             <td class="table-active"><label for="eventFinish">イベント終了時間</label></td>
                             <td>
                                 @if (!empty($reservation->board_flag))
-                                    {{ ReservationHelper::formatTime($reservation->event_finish) }}
+                                    {{ $reservation->event_finish === '00:00:00' ?  '' : ReservationHelper::formatTime($reservation->event_finish) }}
                                 @endif
                             </td>
                         </tr>


### PR DESCRIPTION
以下対応を行いました。
・案内板をありにした場合のデフォルトを入退室時間にする
・編集時にブランクの選択肢を表示をしない
・00時00分が選択された場合、詳細・確認画面でブランクを表示する

バックログ：
https://ts-pj.backlog.com/view/SMG-199