### PR TITLE
催促・督促メール修正

### DIFF
--- a/app/Console/Commands/CommandCronPayDayTwoDaysLeft.php
+++ b/app/Console/Commands/CommandCronPayDayTwoDaysLeft.php
@@ -43,20 +43,21 @@ class CommandCronPayDayTwoDaysLeft extends Command
    */
   public function handle()
   {
-    //キャンセルしていない予約の２営業日前抽出
     $targetPaymentLimit = $this->getSalesDate('ADD'); //addDays
-    $bills = $this->BillQuey($targetPaymentLimit);
-    foreach ($bills as $b) {
-      $SendSMGEmail = new SendSMGEmail();
-      $SendSMGEmail->CronSend("入金期日2営業日前(催促)", $b);
-    }
+    if ($targetPaymentLimit) {
+      // キャンセルしていない予約の２営業日前抽出
+      $bills = $this->BillQuey($targetPaymentLimit);
+      foreach ($bills as $b) {
+        $SendSMGEmail = new SendSMGEmail();
+        $SendSMGEmail->CronSend("入金期日2営業日前(催促)", $b);
+      }
 
-    //キャンセルの２営業日前抽出
-    $targetPaymentLimit = $this->getSalesDate('ADD'); //addDays
-    $cxls = $this->CxlQuey($targetPaymentLimit);
-    foreach ($cxls as $c) {
-      $SendSMGEmail = new SendSMGEmail();
-      $SendSMGEmail->CronSend("入金期日2営業日前(催促)", $c);
+      // キャンセルの２営業日前抽出
+      $cxls = $this->CxlQuey($targetPaymentLimit);
+      foreach ($cxls as $c) {
+        $SendSMGEmail = new SendSMGEmail();
+        $SendSMGEmail->CronSend("入金期日2営業日前(催促)", $c);
+      }
     }
   }
 
@@ -71,6 +72,11 @@ class CommandCronPayDayTwoDaysLeft extends Command
     $tarAry = [];
     for ($i = 1; $i <= 14; $i++) {
       $today = Carbon::today();
+
+      // 実行日が土日祝の場合、実行しない
+      if ($today->isSaturday() || $today->isSunday() || in_array(date('Ymd', strtotime($today)), $holidays)) {
+        return false;
+      }
       $add_or_sub_day = ($add_or_sub === "ADD" ? $today->addDays($i) : $today->subDays($i));
       if (!$add_or_sub_day->isSaturday() && !$add_or_sub_day->isSunday() && !in_array(date('Ymd', strtotime($add_or_sub_day)), $holidays)) {
         $tarAry[] = date('Y-m-d', strtotime($add_or_sub_day));
@@ -131,14 +137,16 @@ class CommandCronPayDayTwoDaysLeft extends Command
         when DAYOFWEEK(bills.payment_limit) = 7 then '(土)'
         end
         ) as payment_limit,
-      venues.smg_url as smg_url
+      venues.smg_url as smg_url,
+      bills.paid as paid
         "
       ))
       ->leftJoin(DB::raw('(select cxls.reservation_id as cxl_reservation_id, cxls.master_total as master_total, cxls.invoice_number as invoice_number, cxls.payment_limit as payment_limit from cxls ) as cxls_list'), 'bills.reservation_id', '=', 'cxls_list.cxl_reservation_id')
       ->leftJoin('reservations', 'reservations.id', '=', 'bills.reservation_id')
       ->leftJoin('users', 'reservations.user_id', '=', 'users.id')
       ->leftJoin('venues', 'venues.id', '=', 'reservations.venue_id')
-      ->whereRaw('reservations.deleted_at is null and bills.deleted_at is null and bills.reservation_status <= 3 and bills.reservation_status <= 3')
+      ->whereRaw('reservations.deleted_at is null and bills.deleted_at is null and bills.reservation_status = 3')
+      ->whereRaw('bills.paid in (0, 2)')
       ->whereRaw('bills.payment_limit = ?', [$targetPaymentLimit])->get();
     return $bills;
   }
@@ -182,13 +190,16 @@ cxls.invoice_number as invoice_number,
         when DAYOFWEEK(cxls.payment_limit) = 7 then '(土)'
         end
         ) as payment_limit,
-venues.smg_url as smg_url
+        venues.smg_url as smg_url,
+        cxls.paid as paid
         "
       ))
       ->leftJoin('reservations', 'reservations.id', '=', 'cxls.reservation_id')
       ->leftJoin('users', 'reservations.user_id', '=', 'users.id')
       ->leftJoin('venues', 'venues.id', '=', 'reservations.venue_id')
       ->whereRaw('reservations.deleted_at is null')
+      ->whereRaw('cxls.paid in (0, 2)')
+      ->whereRaw('cxls.cxl_status = 2')
       ->whereRaw('cxls.payment_limit = ?', [$targetPaymentLimit])->get();
 
     return $cxls;

--- a/resources/views/user/reservations/check.blade.php
+++ b/resources/views/user/reservations/check.blade.php
@@ -342,7 +342,7 @@
                             </td>
                         </tr>
                     @endif
-                    @if (ReservationHelper::checkServiceBreakdowns($request->all()) != 0 || $request->luggage_flag || $request->luggage_count || $request->luggage_arrive || $request->luggage_return)
+                    @if (ReservationHelper::checkServiceBreakdowns($request->all()) != 0 || $request->luggage_flag)
                         <tr>
                             <th class=""><label for="service">有料サービス</label></th>
                             <td>
@@ -357,7 +357,7 @@
                                         {{ Form::hidden('service_breakdown_count[]', $service_result[2]) }}
                                         {{ Form::hidden('service_breakdown_subtotal[]', ReservationHelper::numTimesNum($service_result[1], $service_result[2])) }}
                                     @endforeach
-                                    @if ($request->luggage_flag || $request->luggage_count || $request->luggage_arrive || $request->luggage_return)
+                                    @if ($request->luggage_flag)
                                         <li>
                                             <p>荷物預かり</p>
                                             <p>500<span>円</span></p>


### PR DESCRIPTION
バックログ：
https://ts-pj.backlog.com/view/SMG-205
https://ts-pj.backlog.com/view/SMG-208

督促・催促メールにつきまして以下条件となるよう修正しました。
🔳支払期日は土日祝関係なし
🔳メール送信条件
　　・メールは土日祝を除く営業日にのみ送信する
　　・予約ステータスは「予約完了・キャンセル」
　　・入金ステータスは「未入金・遅延」
　　※※※その他は省略※※※


##############################################
バックログ：
https://ts-pj.backlog.com/view/SMG-20
また上記タスクに漏れがあり、
簡単な修正のため合わせて対応を行いました。
🔳ユーザー側の入力内容確認画面にて荷物預かりを「なし」にしても、
　荷物預かりのオプションが何かしら入っていたら料金内訳に有料サービスが表示されていたため修正