### PR TITLE
SMG-213：顧客登録の支払い期日の選択内容の起算が土日祝を除く起算

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -169,16 +169,34 @@ class User extends Authenticatable
 			$limit = Carbon::parse($date->subDays($subDays));
 		} elseif ($this->pay_limit == 3) {
 			$limit = $date->endOfMonth();
+      $limit = $this->check_holiday($limit);
 		} elseif ($this->pay_limit == 4) {
 			$months = 1; // 追加する月数
 			$limit = $date->day(1)->addMonths($months)->endOfMonth();
+      $limit = $this->check_holiday($limit);
 		} elseif ($this->pay_limit == 5) {
 			$months = 2; // 追加する月数
 			$limit = $date->day(1)->addMonths($months)->endOfMonth();
+      $limit = $this->check_holiday($limit);
 		}
 		$result = Carbon::parse($limit)->toDateTimeString();
 		return date("Y-m-d", strtotime($result));
 	}
+
+  public function check_holiday($checkDay)
+  {
+    $HOLIDAY_CHECK_MAX_COUNT = 14;
+    $holidays = Yasumi::create('Japan', date('Y', strtotime($checkDay)));
+    for ($i = 1; $i <= $HOLIDAY_CHECK_MAX_COUNT; $i++) {
+      if ($checkDay->isSunday() || $checkDay->isSaturday() || $holidays->isHoliday($checkDay)) {
+        $checkDay = $checkDay->subDays(1);
+      } else {
+        break;
+      }
+    }
+    $limitWeekDay = $checkDay;
+    return $limitWeekDay;
+  }
 
   public function getCompany()
   {


### PR DESCRIPTION
バックログ：
https://ts-pj.backlog.com/view/SMG-213

顧客の支払ステータスが以下の場合も、土日祝を除く処理を追加しました。
・当月末締め／当月末支払い
・当月末締め／翌月末支払い
・当月末締め／翌々月末支払い