### PR TITLE
SMG-211：データベースに保存されているメールテンプレートから「margin: 3px;」を削除する

### DIFF
--- a/app/Http/Controllers/Admin/MailTemplatesController.php
+++ b/app/Http/Controllers/Admin/MailTemplatesController.php
@@ -34,6 +34,7 @@ class MailTemplatesController extends Controller
 		]);
 
 		$data = $request->all();
+		$data['body'] = str_replace('<p', '<p style="margin:3px"', $data['body']);
 		$template = MailTemplate::find($data['id'])
 			->update(
 				[


### PR DESCRIPTION
メールが送信された際に不要な縦余白が含まれている件について調査した結果、
むしろ「margin: 3px」が必要なことが判明しました。

画面上から更新を行った際に「margin: 3px」が消えてしまうため、プログラム上で追加するよう修正しました。
文字に色を付ける、太くするなどのコーディングが加えられている場合でも反映されていることを確認済みです。