### PR TITLE
SMG-215：入金催促メールの不具合修正

### DIFF
--- a/app/Console/Commands/CommandCronPayDayTwoDaysLeft.php
+++ b/app/Console/Commands/CommandCronPayDayTwoDaysLeft.php
@@ -44,7 +44,6 @@ class CommandCronPayDayTwoDaysLeft extends Command
   public function handle()
   {
     $targetPaymentLimit = $this->getSalesDate();
-    echo $targetPaymentLimit;
     if ($targetPaymentLimit) {
       // キャンセルしていない予約の２営業日前抽出
       $bills = $this->BillQuey($targetPaymentLimit);
@@ -91,7 +90,7 @@ class CommandCronPayDayTwoDaysLeft extends Command
     if ($tarAry[0] === $tarAry[2]) {
       $targetPaymentLimit = $tarAry[0];
     } else {
-      $targetPaymentLimit = $tarAry[0] . ", " . $tarAry[2];
+      $targetPaymentLimit = "'" . $tarAry[0] . "', '" . $tarAry[2] . "'";
     }
 
     return $targetPaymentLimit;
@@ -154,7 +153,7 @@ class CommandCronPayDayTwoDaysLeft extends Command
       ->leftJoin('venues', 'venues.id', '=', 'reservations.venue_id')
       ->whereRaw('reservations.deleted_at is null and bills.deleted_at is null and bills.reservation_status = 3')
       ->whereRaw('bills.paid in (0, 2)')
-      ->whereRaw('bills.payment_limit in (?)', [$targetPaymentLimit])->get();
+      ->whereRaw('bills.payment_limit in (' . $targetPaymentLimit . ')')->get();
     return $bills;
   }
 

--- a/app/Console/Commands/CommandPayDayOverLimit.php
+++ b/app/Console/Commands/CommandPayDayOverLimit.php
@@ -44,7 +44,6 @@ class CommandPayDayOverLimit extends Command
   {
 
     $targetPaymentLimit = $this->getSalesDate();
-    echo $targetPaymentLimit;
     if ($targetPaymentLimit) {
       // キャンセルしていない予約の1営業日後抽出
       $bills = $this->BillQuey($targetPaymentLimit);
@@ -92,9 +91,9 @@ class CommandPayDayOverLimit extends Command
     $targetPaymentLimit = '';
     foreach ($tarAry as $index => $date) {
       if ($index === 0) {
-        $targetPaymentLimit = $date;
+        $targetPaymentLimit = "'" . $date . "'";
       } else {
-        $targetPaymentLimit = $targetPaymentLimit . ', ' . $date;
+        $targetPaymentLimit = $targetPaymentLimit . ", '" . $date . "'";
       }
     }
 
@@ -151,7 +150,7 @@ class CommandPayDayOverLimit extends Command
       ->leftJoin('venues', 'venues.id', '=', 'reservations.venue_id')
       ->whereRaw('reservations.deleted_at is null and bills.deleted_at is null and bills.reservation_status = 3 and users.id > 0')
       ->whereRaw('bills.paid in (0, 2)')
-      ->whereRaw('bills.payment_limit = ?', [$targetPaymentLimit])->get();
+      ->whereRaw('bills.payment_limit in (' . $targetPaymentLimit . ')')->get();
     return $bills;
   }
 

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -158,11 +158,8 @@ class User extends Authenticatable
 			$subDays = 3;
 			for ($i = 1; $i <= $subDays; $i++) {
 				$checkDay = Carbon::parse($reserve_date)->subDays($i);
-				if ($checkDay->isSunday() || $checkDay->isSaturday()) {
-					$subDays++;
-				}
 				$holidays = Yasumi::create('Japan', date('Y', strtotime($checkDay)));
-				if ($holidays->isHoliday($checkDay)) {
+        if ($checkDay->isSunday() || $checkDay->isSaturday() || $holidays->isHoliday($checkDay)) {
 					$subDays++;
 				}
 			}


### PR DESCRIPTION
app/Console/Commands/CommandCronPayDayTwoDaysLeft.php
app/Console/Commands/CommandPayDayOverLimit.php
催促メールが送られていなかった不具合修正
→複数の送信日がある場合の処理に不備があったため修正しました

app/Models/User.php
営業日の算出がおかしい件
→日付判定 処理にて、
　土日か祝日かをそれぞれ判定していたため、
　「土日もしくは祝日か」に変更しました。
