### PR TITLE
SMG-161 一括仮押さえ一覧の一括仮押さえID、予約一覧の予約一括ID、売上請求一覧の予約一括IDの検索を有効にする

### DIFF
--- a/app/Http/Controllers/Admin/ClientsController.php
+++ b/app/Http/Controllers/Admin/ClientsController.php
@@ -6,13 +6,11 @@ use Illuminate\Http\Request;
 use App\Http\Controllers\Controller;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\DB;
-
 use App\Models\User;
-
 use App\Traits\PaginatorTrait;
 use App\Traits\SortTrait;
 use App\Traits\SearchTrait;
-
+use App\Http\Requests\ClientsRequest;
 
 
 class ClientsController extends Controller
@@ -26,7 +24,7 @@ class ClientsController extends Controller
    *
    * @return \Illuminate\Http\Response
    */
-  public function index(Request $request)
+  public function index(ClientsRequest $request)
   {
     $data = $request->all();
     $user = new User;

--- a/app/Http/Controllers/Admin/MultiplesController.php
+++ b/app/Http/Controllers/Admin/MultiplesController.php
@@ -23,6 +23,7 @@ use Carbon\Carbon;
 use App\Service\SendSMGEmail;
 use App\Consts\MailTemplateConst;
 use App\Mail\UserPreResCxl;
+use App\Http\Requests\MultiplesRequest;
 
 
 class MultiplesController extends Controller
@@ -31,7 +32,7 @@ class MultiplesController extends Controller
 	use PaginatorTrait;
 
 
-	public function index(Request $request)
+	public function index(MultiplesRequest $request)
 	{
 		$data = $request->all();
 

--- a/app/Http/Controllers/Admin/PreReservationsController.php
+++ b/app/Http/Controllers/Admin/PreReservationsController.php
@@ -28,6 +28,7 @@ use App\Http\Requests\Admin\PreReservations\Common\VenuePriceRequiredRequest;
 use App\Service\SendSMGEmail;
 use App\Consts\MailTemplateConst;
 use App\Mail\UserPreResCxl;
+use App\Http\Requests\PreReservationsRequest;
 
 
 class PreReservationsController extends Controller
@@ -41,7 +42,7 @@ class PreReservationsController extends Controller
    *
    * @return \Illuminate\Http\Response
    */
-  public function index(Request $request)
+  public function index(PreReservationsRequest $request)
   {
     $data = $request->all();
     $_pre_reservations = new PreReservation;

--- a/app/Http/Controllers/Admin/ReservationsController.php
+++ b/app/Http/Controllers/Admin/ReservationsController.php
@@ -19,18 +19,14 @@ use Illuminate\Support\Facades\DB; //トランザクション用
 use PDF;
 use App\Mail\SendUserApprove;
 use Illuminate\Support\Facades\Mail;
-
 use App\Traits\PregTrait;
 use Illuminate\Support\Facades\Auth;
-
 use App\Traits\PaginatorTrait;
 use App\Traits\SortTrait;
 use App\Traits\SearchTrait;
-
-// ふぉーむリクエスト
 use App\Http\Requests\Admin\Reservations\ReservationsStore;
-
 use App\Service\SendSMGEmail;
+use App\Http\Requests\ReservationsRequest;
 
 
 class ReservationsController extends Controller
@@ -45,7 +41,7 @@ class ReservationsController extends Controller
    *
    * @return \Illuminate\Http\Response
    */
-  public function index(Request $request)
+  public function index(ReservationsRequest $request)
   {
 
     $venues = Venue::all()->toArray();

--- a/app/Http/Controllers/Admin/SalesController.php
+++ b/app/Http/Controllers/Admin/SalesController.php
@@ -13,17 +13,16 @@ use App\Models\Venue;
 use App\Models\Enduser;
 use App\Models\Cxl;
 use Carbon\Carbon;
-
 use App\Traits\PaginatorTrait;
 use App\Traits\SearchTrait;
-
 use App\Http\Helpers\ReservationHelper;
+use App\Http\Requests\SalesRequest;
 
 class SalesController extends Controller
 {
   use PaginatorTrait;
   use SearchTrait;
-  public function index(Request $request)
+  public function index(SalesRequest $request)
   {
 
     $_reservation = new Reservation;

--- a/app/Http/Requests/ClientsRequest.php
+++ b/app/Http/Requests/ClientsRequest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class ClientsRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'search_id' => ['nullable', 'regex:/^[0-9]+$/i'],
+        ];
+    }
+
+    public function attributes()
+    {
+        return [
+            'search_id' => '顧客ID',
+        ];
+    }
+
+    public function messages()
+    {
+        return [
+            'search_id.regex' => ':attributeは半角数字で入力してください。',
+        ];
+    }
+}

--- a/app/Http/Requests/MultiplesRequest.php
+++ b/app/Http/Requests/MultiplesRequest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class MultiplesRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'search_id' => ['nullable', 'regex:/^[0-9]+$/i'],
+        ];
+    }
+
+    public function attributes()
+    {
+        return [
+            'search_id' => '一括仮押えID',
+        ];
+    }
+
+    public function messages()
+    {
+        return [
+            'search_id.regex' => ':attributeは半角数字で入力してください。',
+        ];
+    }
+}

--- a/app/Http/Requests/PreReservationsRequest.php
+++ b/app/Http/Requests/PreReservationsRequest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class PreReservationsRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'search_id' => ['nullable', 'regex:/^[0-9]+$/i'],
+        ];
+    }
+
+    public function attributes()
+    {
+        return [
+            'search_id' => '仮押えID',
+        ];
+    }
+
+    public function messages()
+    {
+        return [
+            'search_id.regex' => ':attributeは半角数字で入力してください。',
+        ];
+    }
+}

--- a/app/Http/Requests/ReservationsRequest.php
+++ b/app/Http/Requests/ReservationsRequest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class ReservationsRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'multiple_id' => ['nullable', 'regex:/^[0-9]+$/i'],
+            'search_id' => ['nullable', 'regex:/^[0-9]+$/i'],
+        ];
+    }
+
+    public function attributes()
+    {
+        return [
+            'multiple_id' => '予約一括ID',
+            'search_id' => '予約ID',
+        ];
+    }
+
+    public function messages()
+    {
+        return [
+            'multiple_id.regex' => ':attributeは半角数字で入力してください。',
+            'search_id.regex' => ':attributeは半角数字で入力してください。',
+        ];
+    }
+}

--- a/app/Http/Requests/SalesRequest.php
+++ b/app/Http/Requests/SalesRequest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class SalesRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'user_id' => ['nullable', 'regex:/^[0-9]+$/i'],
+            'search_id' => ['nullable', 'regex:/^[0-9]+$/i'],
+            'multiple_id' => ['nullable', 'regex:/^[0-9]+$/i'],
+            'sogaku' => ['nullable', 'regex:/^[0-9]+$/i'],
+        ];
+    }
+
+    public function attributes()
+    {
+        return [
+            'user_id' => '顧客ID',
+            'search_id' => '予約ID',
+            'multiple_id' => '予約一括ID',
+            'sogaku' => '総額',
+        ];
+    }
+
+    public function messages()
+    {
+        return [
+            'user_id.regex' => ':attributeは半角数字で入力してください。',
+            'search_id.regex' => ':attributeは半角数字で入力してください。',
+            'multiple_id.regex' => ':attributeは半角数字で入力してください。',
+            'sogaku.regex' => ':attributeは半角数字で入力してください。',
+        ];
+    }
+}

--- a/app/Models/MultipleReserve.php
+++ b/app/Models/MultipleReserve.php
@@ -843,7 +843,7 @@ class MultipleReserve extends Model implements PresentableInterface //プレゼ�
       ->leftJoin('unknown_users', 'pre_reservations.id', '=', 'unknown_users.pre_reservation_id')
       ->leftJoin('agents', 'pre_reservations.agent_id', '=', 'agents.id')
       ->leftJoin('pre_endusers', 'pre_reservations.id', '=', 'pre_endusers.pre_reservation_id')
-      ->groupByRaw("multiple_reserves.id, users.id, unknown_users.unknown_user_company, agents.name, pre_endusers.company")
+      ->groupByRaw("multiple_reserves.id, users.id, unknown_users.unknown_user_company, agents.name, pre_endusers.company, multiple_reserves.created_at, users.company, users.first_name, users.last_name, users.mobile, users.tel, users.attention")
       ->havingRaw('pre_reservation_count > 0');
     return $searchTarget;
   }
@@ -852,9 +852,9 @@ class MultipleReserve extends Model implements PresentableInterface //プレゼ�
   {
     $searchTarget = $this->MultipleSearchTarget();
 
-    if (!empty($data['search_id']) && (int)$data['search_id'] > 0) {
-		$id = abs($data['search_id']);
-      $searchTarget->whereRaw('multiple_reserve_id LIKE ? ',  ['%' . $id . '%']);
+    if (isset($data['search_id']) && $data['search_id'] !== '') {
+			$searchId = trim($data['search_id'], "0");
+      $searchTarget->whereRaw('multiple_reserve_id = ? ',  $searchId);
     }
 
     if (!empty($data['search_created_at'])) {

--- a/app/Models/MultipleReserve.php
+++ b/app/Models/MultipleReserve.php
@@ -853,7 +853,7 @@ class MultipleReserve extends Model implements PresentableInterface //プレゼ�
     $searchTarget = $this->MultipleSearchTarget();
 
     if (isset($data['search_id']) && $data['search_id'] !== '') {
-			$searchId = trim($data['search_id'], "0");
+      $searchId = (int)$data['search_id'];
       $searchTarget->whereRaw('multiple_reserve_id = ? ',  $searchId);
     }
 

--- a/app/Models/PreReservation.php
+++ b/app/Models/PreReservation.php
@@ -631,16 +631,9 @@ class PreReservation extends Model
   {
     $searchTarget = $this->PreReservationSearchTarget();
 
-    if (!empty($data['search_id']) && (int)$data['search_id'] > 0) {
-		$id=null;
-      for ($i = 0; $i < strlen($data['search_id']); $i++) {
-        if ((int)$data['search_id'][$i] !== 0) {
-          $id = strstr($data['search_id'], $data['search_id'][$i]);
-          break;
-        }
-      }
-
-      $searchTarget->whereRaw('pre_reservations.id LIKE ? ',  ['%' . $id . '%']);
+    if (isset($data['search_id']) && $data['search_id'] !== '') {
+			$searchId = trim($data['search_id'], "0");
+      $searchTarget->whereRaw('pre_reservations.id = ? ',  $searchId);
     }
 
     if (!empty($data['search_created_at'])) {

--- a/app/Models/PreReservation.php
+++ b/app/Models/PreReservation.php
@@ -632,7 +632,7 @@ class PreReservation extends Model
     $searchTarget = $this->PreReservationSearchTarget();
 
     if (isset($data['search_id']) && $data['search_id'] !== '') {
-			$searchId = trim($data['search_id'], "0");
+			$searchId = (int)$data['search_id'];
       $searchTarget->whereRaw('pre_reservations.id = ? ',  $searchId);
     }
 

--- a/app/Models/Reservation.php
+++ b/app/Models/Reservation.php
@@ -304,31 +304,20 @@ class Reservation extends Model implements PresentableInterface
 		$id = null;
 		$searchTarget = $this->ReservationSearchTarget();
 
-		if (!empty($data['multiple_id']) ) 
-		{		
-			$id = abs($data['multiple_id']);
-			// $searchTarget->whereRaw('reservations.multiple_reserve_id LIKE ? ', ['%' . $id . '%']);
-			$searchTarget->whereRaw('reservations.multiple_reserve_id LIKE ? ',  ['%' . $id . '%']);
+		if (isset($data['multiple_id']) && $data['multiple_id'] !== '') {
+			$multipleId = trim($data['multiple_id']);
+			$searchTarget->whereRaw('reservations.multiple_reserve_id = ? ',  $multipleId);
 		}
 
-		if (!empty($data['search_id']) && (int)$data['search_id'] > 0) {
-			for ($i = 0; $i < strlen($data['search_id']); $i++) {
-				if ((int)$data['search_id'][$i] !== 0) {
-					$id = substr($data['search_id'], $i, strlen($data['search_id']));
-					break;
-				}
-			}
-			$searchTarget->whereRaw('reservations.id LIKE ? ',  ['%' . $id . '%']);
+		if (isset($data['search_id']) && $data['search_id'] !== '') {
+			$searchId = trim($data['search_id'], "0");
+
+			$searchTarget->whereRaw('reservations.id = ?', $searchId);
 		}
 
-		if (!empty($data['user_id']) && (int)$data['user_id'] > 0) {
-			for ($i = 0; $i < strlen($data['user_id']); $i++) {
-				if ((int)$data['user_id'][$i] !== 0) {
-					$id = strstr($data['user_id'], $data['user_id'][$i]);
-					break;
-				}
-			}
-			$searchTarget->whereRaw('users.id = ?', [$id]);
+		if (isset($data['user_id']) && $data['user_id'] !== '') {
+			$userId = trim($data['user_id'], "0");
+			$searchTarget->whereRaw('users.id = ?', [$userId]);
 		}
 
 		if (!empty($data['reserve_date'])) {

--- a/app/Models/Reservation.php
+++ b/app/Models/Reservation.php
@@ -305,17 +305,17 @@ class Reservation extends Model implements PresentableInterface
 		$searchTarget = $this->ReservationSearchTarget();
 
 		if (isset($data['multiple_id']) && $data['multiple_id'] !== '') {
-			$multipleId = trim($data['multiple_id']);
+			$multipleId = (int)$data['multiple_id'];
 			$searchTarget->whereRaw('reservations.multiple_reserve_id = ? ',  $multipleId);
 		}
 
 		if (isset($data['search_id']) && $data['search_id'] !== '') {
-			$searchId = trim($data['search_id'], "0");
+			$searchId = (int)$data['search_id'];
 			$searchTarget->whereRaw('reservations.id = ?', $searchId);
 		}
 
 		if (isset($data['user_id']) && $data['user_id'] !== '') {
-			$userId = trim($data['user_id'], "0");
+			$userId = (int)$data['user_id'];
 			$searchTarget->whereRaw('users.id = ?', [$userId]);
 		}
 
@@ -360,8 +360,8 @@ class Reservation extends Model implements PresentableInterface
 			$searchTarget->whereRaw('endusers.company LIKE ? ',  ['%' . $data['enduser_person'] . '%']);
 		}
 
-		if (!empty($data['sogaku'])) {
-			$searchTarget->whereRaw('sogaku = ?', [$data['sogaku']]);
+		if (isset($data['sogaku'])) {
+			$searchTarget->whereRaw('sogaku = ?', [(int)$data['sogaku']]);
 		}
 
 		if (!empty($data['payment_limit'])) {

--- a/app/Models/Reservation.php
+++ b/app/Models/Reservation.php
@@ -311,7 +311,6 @@ class Reservation extends Model implements PresentableInterface
 
 		if (isset($data['search_id']) && $data['search_id'] !== '') {
 			$searchId = trim($data['search_id'], "0");
-
 			$searchTarget->whereRaw('reservations.id = ?', $searchId);
 		}
 

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -236,14 +236,10 @@ class User extends Authenticatable
   public function search($ary)
   {
     $users = $this->search_target();
-    if (!empty($ary['search_id'])) {
-      for ($i = 0; $i < strlen($ary['search_id']); $i++) {
-        if ((int)$ary['search_id'][$i] !== 0) {
-          $id = substr($ary['search_id'], $i, strlen($ary['search_id']));
-          break;
-        }
-      }
-      $users = $users->whereRaw('users.id like ?', ['%' . $id . '%']);
+
+    if (isset($ary['search_id']) && $ary['search_id'] !== '') {
+      $searchId = (int)$ary['search_id'];
+      $users = $users->whereRaw('users.id = ?', $searchId);
     }
     if (!empty($ary['search_company'])) {
       $users = $users->whereRaw('users.company like ?', ['%' . $ary['search_company'] . '%']);

--- a/resources/views/admin/clients/index.blade.php
+++ b/resources/views/admin/clients/index.blade.php
@@ -19,6 +19,8 @@
         <h2 class="mt-3 mb-3">顧客管理　一覧</h2>
         <hr>
 
+        @include('layouts.admin.errors')
+
         <!-- 検索-------------------------------------------------------- -->
         {{ Form::open(['url' => '/admin/clients', 'method' => 'GET', 'id' => 'clients_search', 'autocomplete' => 'off']) }}
         @csrf

--- a/resources/views/admin/multiples/index.blade.php
+++ b/resources/views/admin/multiples/index.blade.php
@@ -20,7 +20,6 @@
   }
 </style>
 
-@include('layouts.admin.errors')
 @if (session('flash_message'))
 <div class="flash_message bg-success text-center py-3 my-0">
   {{ session('flash_message') }}
@@ -47,6 +46,8 @@
       <h2 class="mt-3 mb-3">一括仮押え 一覧</h2>
       <hr>
     </div>
+
+    @include('layouts.admin.errors')
 
     <!-- 検索--------------------------------------- -->
     {{Form::open(['url' => '/admin/multiples', 'method' => 'GET', 'id'=>'searchMultiple','autocomplete'=>'off',])}}

--- a/resources/views/admin/reservations/index.blade.php
+++ b/resources/views/admin/reservations/index.blade.php
@@ -34,6 +34,9 @@
       <h2 class="mt-3 mb-3">予約一覧</h2>
       <hr>
     </div>
+    @foreach ($errors->all() as $error)
+      <p class="is-error" style="color: red">{{ $error }}</p>
+    @endforeach
 
     {{ Form::open(['url' => '/admin/reservations', 'method'=>'get', 'id'=>'reserve_search','autocomplete'=>'off',])}}
     @csrf

--- a/resources/views/admin/reservations/index.blade.php
+++ b/resources/views/admin/reservations/index.blade.php
@@ -27,6 +27,8 @@
 
 </style>
 
+@include('layouts.admin.errors')
+
 <div class="content">
   <div class="container-fluid">
     <div class="container-field mt-3">
@@ -34,9 +36,6 @@
       <h2 class="mt-3 mb-3">予約一覧</h2>
       <hr>
     </div>
-    @foreach ($errors->all() as $error)
-      <p class="is-error" style="color: red">{{ $error }}</p>
-    @endforeach
 
     {{ Form::open(['url' => '/admin/reservations', 'method'=>'get', 'id'=>'reserve_search','autocomplete'=>'off',])}}
     @csrf

--- a/resources/views/admin/reservations/index.blade.php
+++ b/resources/views/admin/reservations/index.blade.php
@@ -27,7 +27,6 @@
 
 </style>
 
-@include('layouts.admin.errors')
 
 <div class="content">
   <div class="container-fluid">
@@ -36,6 +35,8 @@
       <h2 class="mt-3 mb-3">予約一覧</h2>
       <hr>
     </div>
+
+    @include('layouts.admin.errors')
 
     {{ Form::open(['url' => '/admin/reservations', 'method'=>'get', 'id'=>'reserve_search','autocomplete'=>'off',])}}
     @csrf

--- a/resources/views/admin/sales/index.blade.php
+++ b/resources/views/admin/sales/index.blade.php
@@ -33,6 +33,7 @@
         }
     </style>
 
+@include('layouts.admin.errors')
 
 
     <div class="container-field mt-3">
@@ -49,11 +50,6 @@
         <h2 class="mt-3 mb-3">売上・請求情報</h2>
         <hr>
     </div>
-    @foreach ($errors->all() as $error)
-        <p class="is-error" style="color: red">{{ $error }}</p>
-    @endforeach
-
-
 
 
     <!-- 検索--------------------------------------- -->

--- a/resources/views/admin/sales/index.blade.php
+++ b/resources/views/admin/sales/index.blade.php
@@ -33,7 +33,6 @@
         }
     </style>
 
-@include('layouts.admin.errors')
 
 
     <div class="container-field mt-3">
@@ -51,6 +50,7 @@
         <hr>
     </div>
 
+    @include('layouts.admin.errors')
 
     <!-- 検索--------------------------------------- -->
     {{ Form::open(['url' => '/admin/sales', 'method' => 'GET', 'id' => 'sales_search', 'autocomplete' => 'off']) }}

--- a/resources/views/admin/sales/index.blade.php
+++ b/resources/views/admin/sales/index.blade.php
@@ -49,6 +49,10 @@
         <h2 class="mt-3 mb-3">売上・請求情報</h2>
         <hr>
     </div>
+    @foreach ($errors->all() as $error)
+        <p class="is-error" style="color: red">{{ $error }}</p>
+    @endforeach
+
 
 
 


### PR DESCRIPTION
https://ts-pj.backlog.com/view/SMG-161

以下画面のID検索に関する修正を行いました。
・http://127.0.0.1:8000/admin/pre_reservations
・http://127.0.0.1:8000/admin/multiples
・http://127.0.0.1:8000/admin/reservations
・http://127.0.0.1:8000/admin/clients
・http://127.0.0.1:8000/admin/sales

１）ID系のバリデーションチェックの追加（各Requestの追加）
２）ID検索のsql文が「like」になっていたためイコールに変更
３）IDの頭に0がある場合、0を除去する処理の修正
４）バリデーションエラーメッセージを表示