### PR TITLE
SMG-75 カート確認画面の文言修正

### DIFF
--- a/resources/views/user/reservations/cart.blade.php
+++ b/resources/views/user/reservations/cart.blade.php
@@ -85,7 +85,7 @@
                                         <ul class="sum-list">
                                             <li>
                                                 <p>
-                                                    {{ ReservationHelper::getVenueForUser((int) $reservation[0]['venue_id']) }}
+                                                    {{ ReservationHelper::getVenueForUser((int) $reservation[0]['venue_id']) }}{{ $reservation[0]['price_system'] == 2 ? '(音響HG)' : '' }}
                                                 </p>
                                             </li>
                                         </ul>
@@ -221,8 +221,8 @@
                                             <p><span
                                                     class="f-wb">{{ ReservationHelper::formatDateJA($t_reservation[0]['date']) }}</span><br
                                                     class="sp">
-                                                 {{ReservationHelper::getVenueForUser($t_reservation[0]["venue_id"])}}
-                                                会場ご利用料
+                                                 {{ReservationHelper::getVenueForUser($t_reservation[0]["venue_id"])}}{{ $t_reservation[0]['price_system'] === '2' ? '(音響HG)' : '' }}
+                                                 会場ご利用料
                                             </p>
                                             <p>{{ number_format($t_reservation[0]['master']) }}<span>円</span></p>
                                         </li>


### PR DESCRIPTION
https://ts-pj.backlog.com/view/SMG-75

対象：ユーザーの予約カート画面（http://127.0.0.1:8000/user/reservations/cart）
①総合計画面の「会場ご利用料」を「（会場名） 会場ご利用料」に変更する
　例）四ツ橋・サンワールドビル2号室 会場ご利用料
②「音響ハイグレード」を選択した場合、会場名の右横に「(音響HG)」を表示する
　　例）四ツ橋・サンワールドビル2号室(音響HG)