### PR TITLE
SMG-65 会員登録画面のパンくず表示を「会場予約」から「会員登録」に修正

### DIFF
--- a/resources/views/layouts/reservation/app.blade.php
+++ b/resources/views/layouts/reservation/app.blade.php
@@ -263,21 +263,7 @@
                 alt="HOME"></span></a>
           <meta itemprop="position" content="1">
         </li>
-        @if(Request::is('user/preusers*'))
-        <li itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
-          <a itemscope itemtype="http://schema.org/Thing" itemprop="item"
-            href="https://system.osaka-conference.com/calendar/">
-            <span itemprop="name"><span class="changeTtl">会員登録</span></span></a>
-          <meta itemprop="position" content="2">
-        </li>
-        @elseif(Request::is('user/register*'))
-        <li itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
-          <a itemscope itemtype="http://schema.org/Thing" itemprop="item"
-            href="https://system.osaka-conference.com/calendar/">
-            <span itemprop="name"><span class="changeTtl">会員登録</span></span></a>
-          <meta itemprop="position" content="2">
-        </li>
-        @elseif(Request::is('timeout'))
+        @if(Request::is('user/preusers*') || Request::is('user/register*') || Request::is('timeout') || Request::is('user/login') || Request::is('user/password/reset') || Request::is('user/password/email'))
         <li itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
           <a itemscope itemtype="http://schema.org/Thing" itemprop="item"
             href="https://system.osaka-conference.com/calendar/">


### PR DESCRIPTION
https://ts-pj.backlog.com/view/SMG-65

認証関連ページのパンくずが全て「会員登録」となるよう修正しました。
↓未対応だったページ↓
・ログイン/会員登録ページ
・パスワードリセット関連ページ