### PR TITLE
SMG-65 会員登録画面のパンくず表示を「会場予約」から「会員登録」に修正

### DIFF
--- a/resources/views/layouts/reservation/app.blade.php
+++ b/resources/views/layouts/reservation/app.blade.php
@@ -263,7 +263,7 @@
                 alt="HOME"></span></a>
           <meta itemprop="position" content="1">
         </li>
-        @if(Request::is('user/preusers*') || Request::is('user/register*') || Request::is('timeout') || Request::is('user/login') || Request::is('user/password/reset') || Request::is('user/password/email'))
+        @if(Request::is('user/preusers*') || Request::is('user/register*') || Request::is('timeout') || Request::is('user/login') || Request::is('user/password*'))
         <li itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
           <a itemscope itemtype="http://schema.org/Thing" itemprop="item"
             href="https://system.osaka-conference.com/calendar/">


### PR DESCRIPTION
https://github.com/daiki-kudou/smg_3/pull/293
上記対応で追記漏れがあったため、修正しました。