### PR TITLE
SMG-164 管理者予約詳細画面で予約の権限確定時[顧客に権限を渡す]ボタンク（青）をクリックしても画面が遷移しないようにする

### DIFF
--- a/app/Http/Controllers/Admin/ReservationsController.php
+++ b/app/Http/Controllers/Admin/ReservationsController.php
@@ -499,7 +499,7 @@ class ReservationsController extends Controller
       DB::rollback();
       return back()->withInput()->withErrors($e->getMessage());
     }
-    return redirect()->route('admin.reservations.index')->with('flash_message', '予約を確定しました');
+    return redirect()->route('admin.reservations.show', $data['reservation_id'])->with('flash_message', '予約を確定しました');
   }
 
   public function edit($id)


### PR DESCRIPTION
https://ts-pj.backlog.com/view/SMG-164#comment-290945615

予約確定後は詳細画面に遷移するよう修正しました。