### PR TITLE
SMG-160 一括仮押さえの際の 会場料金の計算不備の改修

### DIFF
--- a/app/Models/MultipleReserve.php
+++ b/app/Models/MultipleReserve.php
@@ -96,7 +96,7 @@ class MultipleReserve extends Model implements PresentableInterface //プレゼ�
           'status' => 0,
           'eat_in' => $requests->cp_master_eat_in,
           'eat_in_prepare' => $requests->cp_master_eat_in_prepare,
-          'luggage_flag' => !empty($requests->cp_master_luggage_flag) ? $requests->cp_master_luggage_flag : 0,
+          'luggage_flag' => ($requests->cp_master_luggage_flag === '1' || $requests->luggage_flag === '1') ? 1 : 0,
           'cost' => $requests->cp_master_cost,
         ]);
 

--- a/app/Models/PreReservation.php
+++ b/app/Models/PreReservation.php
@@ -246,7 +246,7 @@ class PreReservation extends Model
         'luggage_flag' => $request->{'luggage_flag_copied' . $splitKey} ?? 0,
       ]);
 
-      $venue_price = empty($result[0][2]) ? 0 : $result[0][2];
+      $venue_price = empty($result[0][0]) ? 0 : $result[0][0];
 
       $equipment_price = empty($result[1][0]) ? 0 : $result[1][0];
 
@@ -270,13 +270,13 @@ class PreReservation extends Model
       ]);
 
       if (!empty($result[0][1])) {
-        $venue_prices = ['会場料金', $result[0][0], $result[0][3], $result[0][0]];
+        $venue_prices = ['会場料金', ($result[0][0] - $result[0][1]), $result[0][3], $result[0][0]];
         $extend_prices = ['延長料金', $result[0][1], $result[0][4], $result[0][1]];
       } elseif (empty($result[0][0])) {
         $venue_prices = [];
         $extend_prices = [];
       } else {
-        $venue_prices = ['会場料金', $result[0][0], $result[0][3], $result[0][0]];
+        $venue_prices = ['会場料金', ($result[0][0] - $result[0][1]), $result[0][3], $result[0][0]];
         $extend_prices = [];
       }
 
@@ -286,7 +286,7 @@ class PreReservation extends Model
             'unit_item' => $venue_prices[0],
             'unit_cost' => $venue_prices[1],
             'unit_count' => $venue_prices[2],
-            'unit_subtotal' => $venue_prices[3],
+            'unit_subtotal' => $venue_prices[1],
             'unit_type' => 1,
           ]);
           $pre_bill->pre_breakdowns()->create([
@@ -301,7 +301,7 @@ class PreReservation extends Model
             'unit_item' => $venue_prices[0],
             'unit_cost' => $venue_prices[1],
             'unit_count' => $venue_prices[2],
-            'unit_subtotal' => $venue_prices[3],
+            'unit_subtotal' => $venue_prices[1],
             'unit_type' => 1,
           ]);
         }

--- a/public/js/lettercounter.js
+++ b/public/js/lettercounter.js
@@ -203,7 +203,8 @@ $(function () {
     $("#luggage_price").css("color", "#ccc");
     $("#changeLuggageArriveDate").css("color", "#ccc");
     $("#luggage_arrive").removeClass("readonly-no-gray");
-    // $(".luggage_info").css("display","none");
+    $(".luggage-table input[type='text']").val("");
+    $(".luggage-table input[type='number']").val("");
   } else {
     $("#luggage_count").prop("readonly", false);
     $("#luggage_count").css("color", "#333!important");
@@ -305,7 +306,8 @@ $(document).on('change', 'input[name*="luggage_flag"]', function () {
     $("#cp_master_luggage_arrive").css("color", "#ccc");
     $("#cp_master_luggage_return").prop("readonly", true);
     $("#cp_master_luggage_return").css("color", "#ccc");
-    // $(".luggage_info").css("display","none");
+    $(".luggage-table input[type='text']").val("");
+    $(".luggage-table input[type='number']").val("");
   } else {
     $("#cp_master_luggage_count").prop("readonly", false);
     $("#cp_master_luggage_count").css("color", "#333");

--- a/resources/views/admin/multiples/calculate.blade.php
+++ b/resources/views/admin/multiples/calculate.blade.php
@@ -379,11 +379,11 @@
                       <td>
                         <div class="radio-box">
                           <p>
-                            {{Form::radio('luggage_flag',1,(int)$request->luggage_flag===1?true:false,['id'=>'cp_master_luggage_flag'])}}
+                            {{Form::radio('luggage_flag',1,($request->cp_master_luggage_flag==='1' || $request->luggage_flag==='1')?true:false,['id'=>'cp_master_luggage_flag'])}}
                             {{Form::label('cp_master_luggage_flag','あり')}}
                           </p>
                           <p>
-                            {{Form::radio('luggage_flag',0,(int)$request->luggage_flag===0?true:false,['id'=>'cp_master_no_luggage_flag'])}}
+                            {{Form::radio('luggage_flag',0,($request->cp_master_luggage_flag==='0' || $request->luggage_flag==='0')?true:false,['id'=>'cp_master_no_luggage_flag'])}}
                             {{Form::label('cp_master_no_luggage_flag','なし')}}
                           </p>
                           <p>500円 (税抜)</p>
@@ -941,11 +941,11 @@
                         <td>
                           <div class="radio-box">
                             <p>
-                              {{Form::radio('luggage_flag_copied'.$key,1,(int)$request->cp_master_luggage_flag===1?true:false,['id'=>'luggage_flag'.$key])}}
+                              {{Form::radio('luggage_flag_copied'.$key,1,($request->cp_master_luggage_flag==='1' || $request->luggage_flag==='1')?true:false,['id'=>'luggage_flag'.$key])}}
                               {{Form::label('luggage_flag'.$key,'あり')}}
                             </p>
                             <p>
-                              {{Form::radio('luggage_flag_copied'.$key,0,(int)$request->cp_master_luggage_flag===0?true:false,['id'=>'no_luggage_flag'.$key])}}
+                              {{Form::radio('luggage_flag_copied'.$key,0,($request->cp_master_luggage_flag==='0' || $request->luggage_flag==='0')?true:false,['id'=>'no_luggage_flag'.$key])}}
                               {{Form::label('no_luggage_flag'.$key,'なし')}}
                             </p>
                             <p>500円 (税抜)</p>


### PR DESCRIPTION
一括仮押さえの編集ページに関して以下修正を行いました。

１）個別日程に反映して保存ボタン押下後の会場料金計算に不備があったため修正しました。
　　⇒詳細：https://ts-pj.backlog.com/view/SMG-160#comment-290878252

２）下記ボタンを押すと荷物預かりの値が保持されていなかったため修正しました。
　　・すべての日程に反映して保存
　　・請求に反映する
　　・個別日程に反映して保存

３）荷物預かりをなしにしても荷物預かり記入欄の値が消えていなかったため、修正しました。

※仲介会社経由の一括仮押さえの修正は別タスクで行うため、今回の対応が考慮されていない可能性があります。
