### PR TITLE
SMG-234 仲介会社の一括仮押さえで、予約に移行時に会場料金が一部、引き継がれない。

### DIFF
--- a/app/Http/Controllers/Admin/MultiplesController.php
+++ b/app/Http/Controllers/Admin/MultiplesController.php
@@ -229,7 +229,7 @@ class MultiplesController extends Controller
 		$end_user_charge = [];
 		foreach ($request->all() as $key => $value) {
 			if (preg_match('/end_user_charge_copied/', $key)) {
-				if (!empty($value)) {
+				if (isset($value)) {
 					$end_user_charge[] = $value;
 				}
 			}

--- a/app/Models/MultipleReserve.php
+++ b/app/Models/MultipleReserve.php
@@ -691,13 +691,11 @@ class MultipleReserve extends Model implements PresentableInterface //プレゼ�
 
         $carbon1 = new Carbon($pre_reservation->enter_time);
         $carbon2 = new Carbon($pre_reservation->leave_time);
-        $usage_hours = $carbon1->diffInMinutes($carbon2);
-        $usage_hours = $usage_hours / 60;
 
         $pre_bill->pre_breakdowns()->create([
           'unit_item' => "会場料金",
           'unit_cost' => 0,
-          'unit_count' => $usage_hours,
+          'unit_count' => 1,
           'unit_subtotal' => 0,
           'unit_type' => 1,
         ]);

--- a/app/Models/PreReservation.php
+++ b/app/Models/PreReservation.php
@@ -425,13 +425,11 @@ class PreReservation extends Model
 
       $carbon1 = new Carbon($this->enter_time);
       $carbon2 = new Carbon($this->leave_time);
-      $usage_hours = $carbon1->diffInMinutes($carbon2);
-      $usage_hours = $usage_hours / 60;
 
       $pre_bill->pre_breakdowns()->create([
         'unit_item' => "会場料金",
         'unit_cost' => 0,
-        'unit_count' => $usage_hours,
+        'unit_count' => 1,
         'unit_subtotal' => 0,
         'unit_type' => 1,
       ]);

--- a/resources/views/admin/agents_reservations/edit.blade.php
+++ b/resources/views/admin/agents_reservations/edit.blade.php
@@ -596,7 +596,7 @@
                 </td>
                 <td>
                     <div class="d-flex align-items-center">
-                        {{ Form::text('end_user_charge', $reservation['bills'][0]['end_user_charge'] ? $reservation['bills'][0]['end_user_charge'] : null, [
+                        {{ Form::text('end_user_charge', $reservation['enduser']['charge'] ?: null, [
                             'class' => 'form-control
                                       ',
                             'placeholder' => '入力してください',

--- a/resources/views/admin/multiples/agent_edit.blade.php
+++ b/resources/views/admin/multiples/agent_edit.blade.php
@@ -937,32 +937,40 @@
                         <td class="table-active">準備</td>
                         <td>
                           <div class="radio-box">
-                            @foreach ($pre_reservation->pre_breakdowns()->get() as $layout_prepares)
-                            @if ($layout_prepares->unit_item=="レイアウト準備料金")
-                            <p>
-                              {{Form::radio('layout_prepare_copied'.$key, 1, true, ['id' =>
-                              'layout_prepare_copied'.$key])}}
-                              {{Form::label('layout_prepare_copied'.$key,'あり')}}
-                            </p>
-                            <p>
-                              {{Form::radio('layout_prepare_copied'.$key, 0, false, ['id' =>
-                              'no_layout_prepare_copied'.$key])}}
-                              {{Form::label('no_layout_prepare_copied'.$key,'なし')}}
-                            </p>
-                            @break
-                            @elseif($loop->last)
-                            <p>
-                              {{Form::radio('layout_prepare_copied'.$key, 1, false, ['id' =>
-                              'layout_prepare_copied'.$key])}}
-                              {{Form::label('layout_prepare_copied'.$key,'あり')}}
-                            </p>
-                            <p>
-                              {{Form::radio('layout_prepare_copied'.$key, 0, true, ['id' =>
-                              'no_layout_prepare_copied'.$key])}}
-                              {{Form::label('no_layout_prepare_copied'.$key,'なし')}}
-                            </p>
+                            @if ($pre_reservation->pre_bill)
+                              @foreach ($pre_reservation->pre_breakdowns()->get() as $layout_prepares)
+                                @if ($layout_prepares->unit_item == 'レイアウト準備料金')
+                                  <p>
+                                    {{ Form::radio('layout_prepare_copied' . $key, 1, true, ['id' => 'layout_prepare_copied' . $key]) }}
+                                    {{ Form::label('layout_prepare_copied' . $key, 'あり') }}
+                                  </p>
+                                  <p>
+                                    {{ Form::radio('layout_prepare_copied' . $key, 0, false, ['id' => 'no_layout_prepare_copied' . $key]) }}
+                                    {{ Form::label('no_layout_prepare_copied' . $key, 'なし') }}
+                                  </p>
+                                @break
+
+                                @elseif($loop->last)
+                                  <p>
+                                    {{ Form::radio('layout_prepare_copied' . $key, 1, false, ['id' => 'layout_prepare_copied' . $key]) }}
+                                    {{ Form::label('layout_prepare_copied' . $key, 'あり') }}
+                                  </p>
+                                  <p>
+                                    {{ Form::radio('layout_prepare_copied' . $key, 0, true, ['id' => 'no_layout_prepare_copied' . $key]) }}
+                                    {{ Form::label('no_layout_prepare_copied' . $key, 'なし') }}
+                                  </p>
+                                @endif
+                              @endforeach
+                            @else
+                              <p>
+                                {{ Form::radio('layout_prepare_copied' . $key, 1, false, ['id' => 'layout_prepare_copied' . $key]) }}
+                                {{ Form::label('layout_prepare_copied' . $key, 'あり') }}
+                              </p>
+                              <p>
+                                {{ Form::radio('layout_prepare_copied' . $key, 0, true, ['id' => 'no_layout_prepare_copied' . $key]) }}
+                                {{ Form::label('no_layout_prepare_copied' . $key, 'なし') }}
+                              </p>
                             @endif
-                            @endforeach
                           </div>
                         </td>
                       </tr>
@@ -970,31 +978,40 @@
                         <td class="table-active">片付</td>
                         <td>
                           <div class="radio-box">
-                            @foreach ($pre_reservation->pre_breakdowns()->get() as $layout_prepares)
-                            @if ($layout_prepares->unit_item=="レイアウト片付料金")
-                            <p>
-                              {{Form::radio('layout_clean_copied'.$key, 1, true, ['id' => 'layout_clean_copied'.$key])}}
-                              {{Form::label('layout_clean_copied'.$key,'あり')}}
-                            </p>
-                            <p>
-                              {{Form::radio('layout_clean_copied'.$key, 0, false, ['id' =>
-                              'no_layout_clean_copied'.$key])}}
-                              {{Form::label('no_layout_clean_copied'.$key,'なし')}}
-                            </p>
-                            @break
-                            @elseif($loop->last)
-                            <p>
-                              {{Form::radio('layout_clean_copied'.$key, 1, false, ['id' =>
-                              'layout_clean_copied'.$key])}}
-                              {{Form::label('layout_clean_copied'.$key,'あり')}}
-                            </p>
-                            <p>
-                              {{Form::radio('layout_clean_copied'.$key, 0, true, ['id' =>
-                              'no_layout_clean_copied'.$key])}}
-                              {{Form::label('no_layout_clean_copied'.$key,'なし')}}
-                            </p>
+                            @if ($pre_reservation->pre_bill)
+                              @foreach ($pre_reservation->pre_breakdowns()->get() as $layout_prepares)
+                                @if ($layout_prepares->unit_item == 'レイアウト片付料金')
+                                  <p>
+                                    {{ Form::radio('layout_clean_copied' . $key, 1, true, ['id' => 'layout_clean_copied' . $key]) }}
+                                    {{ Form::label('layout_clean_copied' . $key, 'あり') }}
+                                  </p>
+                                  <p>
+                                    {{ Form::radio('layout_clean_copied' . $key, 0, false, ['id' => 'no_layout_clean_copied' . $key]) }}
+                                    {{ Form::label('no_layout_clean_copied' . $key, 'なし') }}
+                                  </p>
+                                @break
+
+                                @elseif($loop->last)
+                                  <p>
+                                    {{ Form::radio('layout_clean_copied' . $key, 1, false, ['id' => 'layout_clean_copied' . $key]) }}
+                                    {{ Form::label('layout_clean_copied' . $key, 'あり') }}
+                                  </p>
+                                  <p>
+                                    {{ Form::radio('layout_clean_copied' . $key, 0, true, ['id' => 'no_layout_clean_copied' . $key]) }}
+                                    {{ Form::label('no_layout_clean_copied' . $key, 'なし') }}
+                                  </p>
+                                @endif
+                              @endforeach
+                            @else
+                              <p>
+                                {{ Form::radio('layout_clean_copied' . $key, 1, false, ['id' => 'layout_clean_copied' . $key]) }}
+                                {{ Form::label('layout_clean_copied' . $key, 'あり') }}
+                              </p>
+                              <p>
+                                {{ Form::radio('layout_clean_copied' . $key, 0, true, ['id' => 'no_layout_clean_copied' . $key]) }}
+                                {{ Form::label('no_layout_clean_copied' . $key, 'なし') }}
+                              </p>
                             @endif
-                            @endforeach
                           </div>
                         </td>
                       </tr>
@@ -1290,6 +1307,7 @@
                       3が備品料金
                       4がサービス料金 --}}
                       {{-- 以下備品 --}}
+                      @if ($pre_reservation->pre_breakdowns()->where('unit_type',2)->count() > 0)
                       <div class="equipment billdetails_content">
                         <table class="table table-borderless">
                           <tr>
@@ -1353,9 +1371,10 @@
                           </tbody>
                         </table>
                       </div>
+                      @endif
 
                       {{-- 以下、レイアウト --}}
-                      @if ($venue->layout!=0)
+                      @if (isset($pre_reservation->pre_bill->layout_price) && $pre_reservation->pre_bill->layout_price > 0)
                       <div class="layout billdetails_content">
                         <table class="table table-borderless">
                           <tr>


### PR DESCRIPTION
https://ts-pj.backlog.com/view/SMG-234

以下を修正しました。
１）一括仮押さえ⇒予約に移行時に会場料金と数量を引き継がせる

２）有料備品・サービスが選択・入力されていない場合、請求内訳に項目を出さないように修正

３）一括仮押さえの編集画面で個別の反映を行うとエラーとなっていたため修正

４）仲介会社経由の場合、予約編集画面でレイアウトに関するラジオボタンが表示されていなかったため修正
